### PR TITLE
fix(docker): error repository name must be lowercase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12 as BASE
+FROM node:16 as base
 
 WORKDIR /app
 COPY package.json \
@@ -11,7 +11,7 @@ RUN node-prune
 # lint and formatting configs are commented out
 # uncomment if you want to add them into the build process
 
-FROM BASE AS DEV
+FROM base AS dev
 COPY nest-cli.json \
   tsconfig.* \
 #  .eslintrc.js \
@@ -24,13 +24,13 @@ RUN yarn
 RUN yarn build
 
 # use one of the smallest images possible
-FROM node:12-alpine
+FROM node:16-alpine
 # get package.json from base
-COPY --from=BASE /app/package.json ./
+COPY --from=base /app/package.json ./
 # get the dist back
-COPY --from=DEV /app/dist/ ./dist/
+COPY --from=dev /app/dist/ ./dist/
 # get the node_modules from the intial cache
-COPY --from=BASE /app/node_modules/ ./node_modules/
+COPY --from=base /app/node_modules/ ./node_modules/
 # expose application port 
 EXPOSE 3000
 # start


### PR DESCRIPTION
Running - `docker build . -t docker-nest` on current file results into:
```
PS C:\Users\Priyam\Documents\testing\nest-docker-template> docker build . -t docker-nest
[+] Building 2.3s (5/5) FINISHED
 => [internal] load build definition from Dockerfile                                     0.0s
 => => transferring dockerfile: 889B                                                     0.0s
 => [internal] load .dockerignore                                                        0.0s
 => => transferring context: 34B                                                         0.0s
 => CANCELED [internal] load metadata for docker.io/library/node:12-alpine               2.2s
 => CANCELED [internal] load metadata for docker.io/library/node:12                      2.2s
 => [auth] library/node:pull token for registry-1.docker.io                              0.0s
failed to solve with frontend dockerfile.v0: failed to create LLB definition: failed to parse stage name "BASE": invalid reference format: repository name must be lowercase
```

This PR fixes that and also updates the `node` version to latest stabled even node version `16`. 